### PR TITLE
修复英文版 installation.md 中的 docker-compose.yml 配置错误

### DIFF
--- a/en/guide/installation.md
+++ b/en/guide/installation.md
@@ -50,9 +50,9 @@
        environment:
          - TZ=Asia/Shanghai
        devices:
-         - /etc/machine-id:/etc/machine-id:ro # Pass the host's machine id into container
          - /dev/net/tun:/dev/net/tun
        volumes:
+         - /etc/machine-id:/etc/machine-id:ro # Pass the host's machine id into container
          - /etc/easytier:/root
        command: -i <ip> --network-name <user> --network-secret <password> -p tcp://<server_address>:11010
    ```


### PR DESCRIPTION
修复了英文文档 installation.md 中 docker-compose.yml 示例配置的错误。该问题仅出现在英文版本中，修改后已与其他语言版本保持一致。