### PR TITLE
docs(installation): refresh Docker Compose example

### DIFF
--- a/en/guide/installation.md
+++ b/en/guide/installation.md
@@ -41,36 +41,41 @@ This section only introduces installation methods.
    ::: details docker-compose.yml
 
    ```yaml [docker-compose.yml]
-   services:
-     watchtower: # Used to automatically update easytier image, delete this part if not needed
-       image: containrrr/watchtower
-       container_name: watchtower
-       restart: unless-stopped
-       environment:
-         - TZ=Asia/Shanghai
-         - WATCHTOWER_NO_STARTUP_MESSAGE
-       volumes:
-         - /var/run/docker.sock:/var/run/docker.sock
-       command: --interval 3600 --cleanup --label-enable
-     easytier:
-       image: easytier/easytier:latest # Domestic users can use m.daocloud.io/docker.io/easytier/easytier:latest
-       hostname: easytier
-       container_name: easytier
-       labels:
-         com.centurylinklabs.watchtower.enable: 'true'
-       restart: unless-stopped
-       network_mode: host
-       cap_add:
-         - NET_ADMIN
-         - NET_RAW
-       environment:
-         - TZ=Asia/Shanghai
-       devices:
-         - /dev/net/tun:/dev/net/tun
-       volumes:
-         - /etc/easytier:/root
-         - /etc/machine-id:/etc/machine-id:ro # Map host machine code
-       command: -d --network-name <user> --network-secret <password> -p tcp://<your-public-ip>:11010
+    services:
+      # watchtower automatically updates the EasyTier image; remove this section if not needed
+      watchtower:
+        image: nickfedor/watchtower
+        container_name: watchtower
+        restart: unless-stopped
+        environment:
+          - TZ=Asia/Shanghai
+          - WATCHTOWER_NO_STARTUP_MESSAGE
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+        command: --interval 3600 --cleanup --label-enable
+
+      easytier:
+        # Users in mainland China can use the DaoCloud mirror
+        # image: m.daocloud.io/docker.io/easytier/easytier:latest
+        image: easytier/easytier:latest
+        hostname: easytier
+        container_name: easytier
+        labels:
+          com.centurylinklabs.watchtower.enable: 'true'
+        restart: unless-stopped
+        network_mode: host
+        cap_add:
+          - NET_ADMIN
+          - NET_RAW
+        environment:
+          - TZ=Asia/Shanghai
+        devices:
+          - /dev/net/tun:/dev/net/tun
+        volumes:
+          - /etc/machine-id:/etc/machine-id:ro
+        command: >
+          -d --network-name <user> --network-secret <password>
+          -p tcp://<public-ip-of-other-peer-or-public-node>:11010
    ```
 
    :::

--- a/guide/installation.md
+++ b/guide/installation.md
@@ -41,36 +41,41 @@
    ::: details docker-compose.yml
 
    ```yaml [docker-compose.yml]
-   services:
-     watchtower: # 用于自动更新easytier镜像，若不需要请删除这部分
-       image: containrrr/watchtower
-       container_name: watchtower
-       restart: unless-stopped
-       environment:
-         - TZ=Asia/Shanghai
-         - WATCHTOWER_NO_STARTUP_MESSAGE
-       volumes:
-         - /var/run/docker.sock:/var/run/docker.sock
-       command: --interval 3600 --cleanup --label-enable
-     easytier:
-       image: easytier/easytier:latest # 国内用户可以使用 m.daocloud.io/docker.io/easytier/easytier:latest
-       hostname: easytier
-       container_name: easytier
-       labels:
-         com.centurylinklabs.watchtower.enable: 'true'
-       restart: unless-stopped
-       network_mode: host
-       cap_add:
-         - NET_ADMIN
-         - NET_RAW
-       environment:
-         - TZ=Asia/Shanghai
-       devices:
-         - /dev/net/tun:/dev/net/tun
-       volumes:
-         - /etc/easytier:/root
-         - /etc/machine-id:/etc/machine-id:ro # 映射宿主机机器码
-       command: -d --network-name <用户> --network-secret <密码> -p tcp://<您的公网IP>:11010
+    services:
+      # watchtower 用于自动更新 EasyTier 镜像，若不需要可以删除此节
+      watchtower:
+        image: nickfedor/watchtower
+        container_name: watchtower
+        restart: unless-stopped
+        environment:
+          - TZ=Asia/Shanghai
+          - WATCHTOWER_NO_STARTUP_MESSAGE
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+        command: --interval 3600 --cleanup --label-enable
+
+      easytier:
+        # 国内用户可以使用 daocloud.io 镜像
+        # image: m.daocloud.io/docker.io/easytier/easytier:latest
+        image: easytier/easytier:latest
+        hostname: easytier
+        container_name: easytier
+        labels:
+          com.centurylinklabs.watchtower.enable: 'true'
+        restart: unless-stopped
+        network_mode: host
+        cap_add:
+          - NET_ADMIN
+          - NET_RAW
+        environment:
+          - TZ=Asia/Shanghai
+        devices:
+          - /dev/net/tun:/dev/net/tun
+        volumes:
+          - /etc/machine-id:/etc/machine-id:ro
+        command: >
+          -d --network-name <用户> --network-secret <密码>
+          -p tcp://<其他对等节点 / 公共节点的公网 IP>:11010
    ```
 
    :::


### PR DESCRIPTION
[containrrr/watchtower](https://github.com/containrrr/watchtower) is archived and no longer alive.

Update the Watchtower image reference and align the bilingual compose example with the current setup guidance.