### PR TITLE
docs: add public server rate limiting guidance

### DIFF
--- a/en/guide/network/host-public-server.md
+++ b/en/guide/network/host-public-server.md
@@ -31,3 +31,94 @@ sudo easytier-core --private-mode true --network-name my-network --network-secre
 ```
 
 This will only allow nodes with network name `my-network` and key `my-secret` to connect to this EasyTier node.
+
+## Frontend Rate Limiting
+
+If a shared node is exposed to the public Internet, put a reverse proxy, L4 gateway, or firewall in front of EasyTier whenever possible. The allocator can help RSS drop after traffic spikes, but it is not a replacement for connection limiting. During CC attacks, prioritize limiting new connections, concurrent connections, slow handshakes, and abnormally large requests.
+
+### WebSocket Entry
+
+If you expose `ws://` or `wss://`, NGINX HTTP reverse proxy can limit request rate and concurrent connections per client IP:
+
+```nginx
+http {
+    limit_req_zone $binary_remote_addr zone=easytier_req_per_ip:20m rate=10r/s;
+    limit_conn_zone $binary_remote_addr zone=easytier_conn_per_ip:20m;
+    limit_conn_zone $server_name zone=easytier_conn_total:20m;
+
+    server {
+        listen 443 ssl http2;
+        server_name example.com;
+
+        location / {
+            limit_req zone=easytier_req_per_ip burst=20 nodelay;
+            limit_conn easytier_conn_per_ip 20;
+            limit_conn easytier_conn_total 20000;
+
+            proxy_pass http://127.0.0.1:11010;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_read_timeout 300s;
+            proxy_send_timeout 30s;
+            client_header_timeout 5s;
+            client_body_timeout 5s;
+            client_max_body_size 1m;
+            large_client_header_buffers 4 8k;
+        }
+    }
+}
+```
+
+For trusted users, increase `limit_conn easytier_conn_per_ip` as needed. During an active attack, lowering it to `3` to `5` is usually a safer starting point.
+
+### TCP Entry
+
+If you expose `tcp://`, NGINX stream can limit L4 connections:
+
+```nginx
+stream {
+    limit_conn_zone $binary_remote_addr zone=easytier_tcp_per_ip:20m;
+
+    server {
+        listen 11010;
+        proxy_pass 127.0.0.1:11011;
+
+        limit_conn easytier_tcp_per_ip 10;
+        proxy_connect_timeout 3s;
+        proxy_timeout 300s;
+    }
+}
+```
+
+In this example, NGINX listens on `11010`, while EasyTier listens on `127.0.0.1:11011`.
+
+### UDP and QUIC Entry
+
+For `udp://` and `quic://`, prefer firewall rules or cloud-provider L4 protection. For example, nftables can apply coarse rate limiting to new UDP traffic:
+
+```shell
+sudo nft add rule inet filter input udp dport 11010 ct state new limit rate over 100/second burst 200 packets drop
+```
+
+Tune the threshold according to bandwidth, CPU capacity, and user scale. Public nodes should keep a whitelist mechanism to avoid blocking many users behind the same NAT egress IP.
+
+### Memory Reclaim Tuning
+
+In CI release builds, common x86 Linux packages use `jemalloc`, while some platforms such as Windows, aarch64, riscv64, loongarch64, and FreeBSD use `mimalloc`.
+
+After v2.6.4, `jemalloc` builds include a more aggressive RSS decay configuration by default. If you need to override it temporarily, add an environment variable to your systemd service:
+
+```ini
+Environment=MALLOC_CONF=background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,retain:false
+```
+
+For `mimalloc` platforms, use:
+
+```ini
+Environment=MIMALLOC_PURGE_DELAY=100
+Environment=MIMALLOC_PURGE_DECOMMITS=1
+```
+
+A smaller purge delay makes RSS drop faster, but can cost more CPU. A larger delay favors performance, but memory will return to the OS more slowly after attack traffic stops.

--- a/guide/network/host-public-server.md
+++ b/guide/network/host-public-server.md
@@ -54,7 +54,7 @@ Wants=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/easytier-core --hostname <your-hostname> --network-name <your-network> --network-secret <your-secret> 
+ExecStart=/usr/local/bin/easytier-core --hostname <your-hostname> --network-name <your-network> --network-secret <your-secret>
 Restart=always
 RestartSec=3
 LimitNOFILE=1048576
@@ -63,6 +63,97 @@ Environment=TOKIO_CONSOLE=1
 [Install]
 WantedBy=multi-user.target
 ```
+
+## 前端限流
+
+如果共享节点直接暴露在公网，建议在 EasyTier 前面放置反向代理、四层网关或防火墙做限流。内存分配器可以帮助被攻击后的 RSS 回落，但不能替代连接限流；CC 攻击时应优先限制新连接、并发连接、慢握手和异常大请求。
+
+### WebSocket 入口
+
+如果使用 `ws://` 或 `wss://` 监听，可以用 NGINX HTTP 反向代理限制每个 IP 的请求速率和并发连接数：
+
+```nginx
+http {
+    limit_req_zone $binary_remote_addr zone=easytier_req_per_ip:20m rate=10r/s;
+    limit_conn_zone $binary_remote_addr zone=easytier_conn_per_ip:20m;
+    limit_conn_zone $server_name zone=easytier_conn_total:20m;
+
+    server {
+        listen 443 ssl http2;
+        server_name example.com;
+
+        location / {
+            limit_req zone=easytier_req_per_ip burst=20 nodelay;
+            limit_conn easytier_conn_per_ip 20;
+            limit_conn easytier_conn_total 20000;
+
+            proxy_pass http://127.0.0.1:11010;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_read_timeout 300s;
+            proxy_send_timeout 30s;
+            client_header_timeout 5s;
+            client_body_timeout 5s;
+            client_max_body_size 1m;
+            large_client_header_buffers 4 8k;
+        }
+    }
+}
+```
+
+如果节点主要服务可信用户，可以适当提高 `limit_conn easytier_conn_per_ip`；如果正在被打，可以先降低到 `3` 到 `5`。
+
+### TCP 入口
+
+如果使用 `tcp://` 监听，可以用 NGINX stream 模块做四层连接数限制：
+
+```nginx
+stream {
+    limit_conn_zone $binary_remote_addr zone=easytier_tcp_per_ip:20m;
+
+    server {
+        listen 11010;
+        proxy_pass 127.0.0.1:11011;
+
+        limit_conn easytier_tcp_per_ip 10;
+        proxy_connect_timeout 3s;
+        proxy_timeout 300s;
+    }
+}
+```
+
+上面的例子中，NGINX 对外监听 `11010`，EasyTier 实际监听 `127.0.0.1:11011`。
+
+### UDP 和 QUIC 入口
+
+`udp://` 和 `quic://` 更适合在防火墙或云厂商四层防护上限流。例如使用 nftables 对新 UDP 流量做粗限速：
+
+```shell
+sudo nft add rule inet filter input udp dport 11010 ct state new limit rate over 100/second burst 200 packets drop
+```
+
+实际阈值需要根据节点带宽、CPU 和用户规模调整。公共节点应保留白名单策略，避免大量用户共用同一个 NAT 出口时被误伤。
+
+### 内存回落配置
+
+CI Release 构建中，常见的 x86 Linux 包使用 `jemalloc`，部分平台（如 Windows、aarch64、riscv64、loongarch64、freebsd）使用 `mimalloc`。
+
+从 v2.6.4 之后，`jemalloc` 构建会内置较积极的 RSS 回落配置。如果需要临时调整，可以在 systemd service 中增加环境变量：
+
+```ini
+Environment=MALLOC_CONF=background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,retain:false
+```
+
+`mimalloc` 平台可以使用：
+
+```ini
+Environment=MIMALLOC_PURGE_DELAY=100
+Environment=MIMALLOC_PURGE_DECOMMITS=1
+```
+
+更小的 purge delay 会让 RSS 更快回落，但可能带来更高的 CPU 开销；更大的 delay 更偏向性能，但攻击流量结束后内存回落会更慢。
 
 ## 配置 fail2ban
 


### PR DESCRIPTION
Adds frontend rate limiting guidance for public EasyTier servers, including WebSocket, TCP, UDP/QUIC examples and allocator memory reclaim tuning.